### PR TITLE
NPM StepAlias Unit Tests example

### DIFF
--- a/libraries/npm/test/UnitTestSpec.groovy
+++ b/libraries/npm/test/UnitTestSpec.groovy
@@ -10,27 +10,33 @@ public class UnitTestSpec extends JTEPipelineSpecification {
   def UnitTest = null
 
   def setup() {
-    UnitTest = loadPipelineScriptForStep("npm","unit_test")
+    UnitTest = loadPipelineScriptForStep("npm","npm_invoke")
   }
 
-  def "npm_invoke called" () {
-    setup:
-      explicitlyMockPipelineStep("npm_invoke")
-      UnitTest.getBinding().setVariable("config", [unit_test: [script: "test", npm_install: "ci"]])
-    when:
+  def "unit test install command used when no app env present"(){
+    given:
+      def config = [
+        unit_test: [
+          npm_install: "unit test install"
+        ]
+      ]
+      def stepContext = [
+        name: "unit_test"
+      ]
+      def env = [:]
+      explicitlyMockPipelineStep("inside_sdp_image")
+      UnitTest.getBinding().setVariable("config", config)
+      UnitTest.getBinding().setVariable("stepContext", stepContext)
+      UnitTest.getBinding().setVariable("env", env)
+    when: 
       UnitTest()
     then:
-      1 * getPipelineMock("npm_invoke").call(['unit_test', []])
+      assert env.npm_install == "unit test install"
   }
 
-  def "npm_invoke called with app_env when present" () {
-    setup:
-      def app_env = [short_name: 'env', long_name: 'Environment', unit_test: [:]]
-      explicitlyMockPipelineStep("npm_invoke")
-      UnitTest.getBinding().setVariable("config", [unit_test: [script: "test", npm_install: "ci"]])
-    when:
-      UnitTest(app_env)
-    then:
-      1 * getPipelineMock("npm_invoke").call(['unit_test', app_env])
-  }
+
+
+
+
+
 }

--- a/libraries/npm/test/UnitTestSpec.groovy
+++ b/libraries/npm/test/UnitTestSpec.groovy
@@ -4,13 +4,14 @@
 */
 
 package libraries.npm
+import spock.lang.Unroll
 
 public class UnitTestSpec extends JTEPipelineSpecification {
 
-  def UnitTest = null
+  def NpmInvoke = null
 
   def setup() {
-    UnitTest = loadPipelineScriptForStep("npm","npm_invoke")
+    NpmInvoke = loadPipelineScriptForStep("npm","npm_invoke")
   }
 
   def "unit test install command used when no app env present"(){
@@ -25,18 +26,40 @@ public class UnitTestSpec extends JTEPipelineSpecification {
       ]
       def env = [:]
       explicitlyMockPipelineStep("inside_sdp_image")
-      UnitTest.getBinding().setVariable("config", config)
-      UnitTest.getBinding().setVariable("stepContext", stepContext)
-      UnitTest.getBinding().setVariable("env", env)
+      NpmInvoke.getBinding().setVariable("config", config)
+      NpmInvoke.getBinding().setVariable("stepContext", stepContext)
+      NpmInvoke.getBinding().setVariable("env", env)
     when: 
-      UnitTest()
+      NpmInvoke()
     then:
       assert env.npm_install == "unit test install"
   }
 
-
-
-
-
+  @Unroll
+  def "step #step: install command reads from lib config when app env is null"(){
+      given:
+        def config = [
+          (step): [
+            npm_install: "unit test install"
+          ]
+        ]
+        def stepContext = [
+          name: step
+        ]
+        def env = [:]
+        explicitlyMockPipelineStep("inside_sdp_image")
+        NpmInvoke.getBinding().setVariable("config", config)
+        NpmInvoke.getBinding().setVariable("stepContext", stepContext)
+        NpmInvoke.getBinding().setVariable("env", env)
+      when: 
+        NpmInvoke()
+      then:
+        assert env.npm_install == "unit test install"
+      where:
+        step | _ 
+        "source_build" | _ 
+        "unit_test" | _
+        "lint_code" | _ 
+  }
 
 }

--- a/resources/test/JTEPipelineSpecification.groovy
+++ b/resources/test/JTEPipelineSpecification.groovy
@@ -1,6 +1,6 @@
 /*
-  Copyright © 2018 Booz Allen Hamilton. All Rights Reserved.
-  This software package is licensed under the Booz Allen Public License. The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
+Copyright © 2018 Booz Allen Hamilton. All Rights Reserved.
+This software package is licensed under the Booz Allen Public License. The license can be found in the License file or at http://boozallen.github.io/licenses/bapl
 */
 
 import com.homeaway.devtools.jenkins.testing.JenkinsPipelineSpecification
@@ -12,40 +12,31 @@ import org.codehaus.groovy.control.customizers.ImportCustomizer
 public class JTEPipelineSpecification extends JenkinsPipelineSpecification {
     @Override
     Script loadPipelineScriptForTest(String _path) {
-		
-		String[] path_parts = _path.split( "/" )
-		
-		String filename = path_parts[path_parts.length-1]
-		
-		String resource_path = "/"
-		if( path_parts.length >= 2 ) {
-			resource_path = String.join( "/", path_parts[0..path_parts.length-2] )
-			resource_path = "/${resource_path}/"
-		}
+        String[] path_parts = _path.split( "/" )
+        String filename = path_parts[path_parts.length-1]
+        String resource_path = "/"
+        if( path_parts.length >= 2 ) {
+            resource_path = String.join( "/", path_parts[0..path_parts.length-2] )
+            resource_path = "/${resource_path}/"
+        }
 
-		GroovyScriptEngine script_engine = new GroovyScriptEngine(generateScriptClasspath(resource_path))
+        GroovyScriptEngine script_engine = new GroovyScriptEngine(generateScriptClasspath(resource_path))
         CompilerConfiguration cc = script_engine.getConfig() 
-        // define auto importing of JTE hook annotations
         ImportCustomizer ic = new ImportCustomizer()
         ic.addStarImports("org.boozallen.plugins.jte.init.primitives.hooks")
-        ic.addImports("com.cloudbees.groovy.cps.NonCPS")
+        ic.addImport("org.boozallen.plugins.jte.init.primitives.injectors.StepAlias")
+        ic.addImport("com.cloudbees.groovy.cps.NonCPS")
         cc.addCompilationCustomizers(ic) 
         script_engine.setConfig(cc)
 
-		Class<Script> script_class = script_engine.loadScriptByName( "${filename}" )
+        Class<Script> script_class = script_engine.loadScriptByName( "${filename}" )
+        Script script = script_class.newInstance()
+        addPipelineMocksToObjects(script)
 
-		Script script = script_class.newInstance()
+        return SourceVersion.isName(script_class.getSimpleName()) ? script : new InvalidlyNamedScriptWrapper(script)
+    }
 
-		addPipelineMocksToObjects( script )
-		
-		if( SourceVersion.isName( script_class.getSimpleName() ) ) {
-			return script
-		} else {
-			return new InvalidlyNamedScriptWrapper( script )
-		}
-	}
-
-	Script loadPipelineScriptForStep(String lib, String step) {	
-		loadPipelineScriptForTest("${lib}/steps/${step}.groovy")
-	}
+    Script loadPipelineScriptForStep(String lib, String step) {
+        loadPipelineScriptForTest("${lib}/steps/${step}.groovy")
+    }
 }


### PR DESCRIPTION
# PR Details

Hey Connor, 

Wanted to provide an example of how you can unit test steps that have Step Aliases.

## Description

A few things had to happen:
1. Update `JenkinsPipelineSpecification` to add the import for the `@StepAlias` annotation so that the steps could compile during the tests.
2. Change the way we were approaching executing the step. Basically, to mock the execution of `npm_invoke` as another step.. all you need to do is mock the `stepContext` variable and set `stepContext.name` to the aliased named you're trying to test. 

